### PR TITLE
fix: restrict space invites to admins of that space

### DIFF
--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -477,6 +477,58 @@ describe('MembersController', () => {
         });
     });
 
+    it('should throw a 401 if the signer is an admin of a different space', async () => {
+      const outsiderAuthPayloadDto = authPayloadDtoBuilder().build();
+      const outsiderAccessToken = jwtService.sign(outsiderAuthPayloadDto);
+      const ownerAuthPayloadDto = authPayloadDtoBuilder().build();
+      const ownerAccessToken = jwtService.sign(ownerAuthPayloadDto);
+      const invitee = getAddress(faker.finance.ethereumAddress());
+      const inviteeName = faker.person.firstName();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${outsiderAccessToken}`])
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${ownerAccessToken}`])
+        .expect(201);
+
+      // Both signers are ACTIVE ADMINs, but each of their own space
+      await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${outsiderAccessToken}`])
+        .send({ name: nameBuilder() })
+        .expect(201);
+
+      const targetSpaceResponse = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${ownerAccessToken}`])
+        .send({ name: nameBuilder() })
+        .expect(201);
+      const targetSpaceId = targetSpaceResponse.body.id;
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${targetSpaceId}/members/invite`)
+        .set('Cookie', [`access_token=${outsiderAccessToken}`])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: invitee,
+              name: inviteeName,
+            },
+          ],
+        })
+        .expect(401)
+        .expect({
+          message: 'Signer is not an active admin.',
+          error: 'Unauthorized',
+          statusCode: 401,
+        });
+    });
+
     it('should throw a 409 if the user is already a member of the space', async () => {
       const adminAuthPayloadDto = authPayloadDtoBuilder().build();
       const adminAccessToken = jwtService.sign(adminAuthPayloadDto);

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -859,6 +859,72 @@ describe('MembersRepository', () => {
         new UnauthorizedException('Signer is not an active admin.'),
       );
     });
+
+    it('should not allow inviting users if the signer is an ADMIN of another space', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const outsider = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      await dbWalletRepo.insert({
+        user: outsider.generatedMaps[0],
+        address: authPayloadDto.signer_address,
+      });
+      const ownSpace = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const targetSpace = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      // The signer administrates ownSpace...
+      await dbMembersRepository.insert({
+        user: outsider.generatedMaps[0],
+        space: ownSpace.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+      // ...whereas targetSpace is administrated by somebody else and the
+      // signer holds no membership in it at all.
+      const targetSpaceAdmin = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      await dbWalletRepo.insert({
+        user: targetSpaceAdmin.generatedMaps[0],
+        address: getAddress(faker.finance.ethereumAddress()),
+      });
+      await dbMembersRepository.insert({
+        user: targetSpaceAdmin.generatedMaps[0],
+        space: targetSpace.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+      const users: Array<{
+        address: Address;
+        role: keyof typeof MemberRole;
+        name: string;
+      }> = [
+        {
+          address: getAddress(faker.finance.ethereumAddress()),
+          role: 'ADMIN',
+          name: nameBuilder(),
+        },
+      ];
+
+      await expect(
+        membersRepository.inviteUsers({
+          authPayload: new AuthPayload(authPayloadDto),
+          spaceId: targetSpace.generatedMaps[0].id,
+          users,
+        }),
+      ).rejects.toThrow(
+        new UnauthorizedException('Signer is not an active admin.'),
+      );
+    });
   });
 
   describe('acceptInvite', () => {

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -103,14 +103,10 @@ export class MembersRepository implements IMembersRepository {
     const space = await this.spacesRepository.findOneOrFail({
       where: { id: args.spaceId },
     });
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    const activeAdmin = await membersRepository.findOne({
-      where: { user: { id: admin.id }, status: 'ACTIVE', role: 'ADMIN' },
+    await this.assertActiveSpaceAdmin({
+      userId: admin.id,
+      spaceId: space.id,
     });
-    if (!activeAdmin) {
-      throw new UnauthorizedException('Signer is not an active admin.');
-    }
 
     const invitedAddresses = args.users.map((user) => user.address);
     const invitedWallets = await this.walletsRepository.find({
@@ -391,6 +387,31 @@ export class MembersRepository implements IMembersRepository {
   ): asserts authPayload is AuthPayload & { signer_address: Address } {
     if (!authPayload.signer_address) {
       throw new UnauthorizedException('Signer address not provided.');
+    }
+  }
+
+  /**
+   * Ensures that the given user holds administrative rights *within the
+   * given space*. Membership is scoped per space, so admin rights in one
+   * space grant no authority in another.
+   */
+  private async assertActiveSpaceAdmin(args: {
+    userId: User['id'];
+    spaceId: Space['id'];
+  }): Promise<void> {
+    const membersRepository =
+      await this.postgresDatabaseService.getRepository(DbMember);
+    const hasAdminRights = await membersRepository.exists({
+      where: {
+        user: { id: args.userId },
+        space: { id: args.spaceId },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      },
+    });
+
+    if (!hasAdminRights) {
+      throw new UnauthorizedException('Signer is not an active admin.');
     }
   }
 


### PR DESCRIPTION
The authorization check in `inviteUsers` looked up an ACTIVE/ADMIN member row for the signer without constraining it to the target space, so an admin of any one space could invite arbitrary members — including with the ADMIN role — into any other space.

Replace the inline query with a dedicated `assertActiveSpaceAdmin` guard that verifies admin rights within the given space, mirroring the scoping already applied by `updateRole`, `removeUser` and the other member operations. Error semantics are unchanged.

Add an integration test covering the repository layer and an e2e test asserting the endpoint answers 401 when the signer administers a different space.

## Summary

## Changes
